### PR TITLE
Fix/exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "a",
+  "name": "@artossystems/a",
   "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "a",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artossystems/a",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Typesafe Redux action creation utility",
   "main": "lib/a.js",
   "scripts": {

--- a/src/a.ts
+++ b/src/a.ts
@@ -12,10 +12,10 @@ export interface ISimpleAction<T extends string> {
   type: T
 }
 
-export type TPayloadAction<T extends string, Payloads extends {} = {}> = ISimpleAction<
-  T
-> &
-  { [K in keyof Payloads]: Payloads[K] }
+export type TPayloadAction<
+  T extends string,
+  Payloads extends {} = {}
+> = ISimpleAction<T> & { [K in keyof Payloads]: Payloads[K] }
 
 /**
  * a

--- a/src/a.ts
+++ b/src/a.ts
@@ -1,18 +1,18 @@
-interface ISimpleA<T, A> {
+export interface ISimpleA<T, A> {
   TYPE: T
   (): A
 }
 
-interface IPayloadA<T, Payloads extends {}, A> {
+export interface IPayloadA<T, Payloads extends {}, A> {
   TYPE: T
   (obj: Payloads): A
 }
 
-interface ISimpleAction<T extends string> {
+export interface ISimpleAction<T extends string> {
   type: T
 }
 
-type TPayloadAction<T extends string, Payloads extends {} = {}> = ISimpleAction<
+export type TPayloadAction<T extends string, Payloads extends {} = {}> = ISimpleAction<
   T
 > &
   { [K in keyof Payloads]: Payloads[K] }


### PR DESCRIPTION
Fixes problems importing "a" that results from not exporting the interfaces.

```
lib/actions.ts:72:7 - error TS4023: Exported variable 'AReduxAction' has or is using name 'ISimpleAction' from external module "/rootPath/node_modules/@artossystems/a/lib/a" but cannot be named.

72 const AReduxAction = a('REDUX_ACTION', {} as { key1: string })
```